### PR TITLE
Update Fare 2.2.0 to prevent System.Net.Http DoS known issue

### DIFF
--- a/src/RandomDataGenerator/RandomDataGenerator.csproj
+++ b/src/RandomDataGenerator/RandomDataGenerator.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Fare" Version="2.1.2" />
+    <PackageReference Include="Fare" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">


### PR DESCRIPTION
Hi @StefH, 
@leolplex and I have requested an update from Fare package to support a new netstandard version to prevent a [Dos Know issue](https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60045). 
A new version of Fare is available: 2.2.0.

Can you accept this PR to upgrade Fare version and generate a nugget package to pass some vulnerabilities scanning  process?? 

Thanks!!!!!
